### PR TITLE
Add gallery admin (upload/edit) and shared Photo types

### DIFF
--- a/src/app/blog/gallery/_components/FilterTags.tsx
+++ b/src/app/blog/gallery/_components/FilterTags.tsx
@@ -1,16 +1,16 @@
 'use client';
 
-interface FilterTagsProps {
-  selectedCategory: string;
-  onCategoryChange: (category: string) => void;
-}
+import { FILTER_CATEGORIES, type FilterCategory } from '@/types/Photo';
 
-const categories = ['all', 'architecture', 'design', 'landscape', 'lifestyle' , 'travel'];
+interface FilterTagsProps {
+  selectedCategory: FilterCategory;
+  onCategoryChange: (category: FilterCategory) => void;
+}
 
 export default function FilterTags({ selectedCategory, onCategoryChange }: FilterTagsProps) {
   return (
     <div className="flex flex-wrap gap-2 justify-center my-4">
-      {categories.map((category) => (
+      {FILTER_CATEGORIES.map((category) => (
         <button
           key={category}
           onClick={() => onCategoryChange(category)}

--- a/src/app/blog/gallery/_components/GalleryContainer.tsx
+++ b/src/app/blog/gallery/_components/GalleryContainer.tsx
@@ -3,9 +3,10 @@ import { useState } from 'react';
 import GalleryViewer from './GalleryViewer';
 import FilterTags from './FilterTags';
 import { Metadata } from 'next';
+import type { Photo, FilterCategory } from '@/types/Photo';
 
 interface GalleryContainerProps {
-  photos: any[];
+  photos: Photo[];
 }
 export const metadata: Metadata = {
     title: 'Photo Gallery | Dujin Kim',
@@ -16,7 +17,7 @@ export const metadata: Metadata = {
       description: 'Explore my personal photography collection',
       images: [
         {
-          url: '/images/dev/photogallery.png', 
+          url: '/images/dev/photogallery.png',
           width: 1200,
           height: 630,
           alt: 'Gallery Cover Photo',
@@ -28,25 +29,25 @@ export const metadata: Metadata = {
       card: 'summary_large_image',
       title: 'Photo Gallery | Dujin Kim',
       description: 'Personal photography collection',
-      images: ['/images/dev/photogallery.png'], 
+      images: ['/images/dev/photogallery.png'],
     },
   };
 export default function GalleryContainer({ photos }: GalleryContainerProps) {
-  const [selectedCategory, setSelectedCategory] = useState('all');
+  const [selectedCategory, setSelectedCategory] = useState<FilterCategory>('all');
 
-  const handleCategoryChange = (category: string) => {
+  const handleCategoryChange = (category: FilterCategory) => {
     setSelectedCategory(category);
   };
 
   return (
     <>
-      <FilterTags 
-        selectedCategory={selectedCategory} 
-        onCategoryChange={handleCategoryChange} 
+      <FilterTags
+        selectedCategory={selectedCategory}
+        onCategoryChange={handleCategoryChange}
       />
-      <GalleryViewer 
-        photos={photos} 
-        selectedCategory={selectedCategory} 
+      <GalleryViewer
+        photos={photos}
+        selectedCategory={selectedCategory}
       />
     </>
   );

--- a/src/app/blog/gallery/_components/GalleryLightbox.tsx
+++ b/src/app/blog/gallery/_components/GalleryLightbox.tsx
@@ -1,27 +1,22 @@
 import React from 'react'
 import {
-    Dialog,
     DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-    DialogTrigger,
 } from "@/components/ui/dialog"
 import Image from 'next/image';
 import { GrNext, GrPrevious } from "react-icons/gr";
 import { cn } from '@/utils/cn';
+import type { Photo } from '@/types/Photo';
 
 interface GalleryLightboxProps {
-    photos: any;
+    photos: Photo[];
     selectedIndex: number;
-    setSelectedIndex: any;
+    setSelectedIndex: React.Dispatch<React.SetStateAction<number | null>>;
 }
 
 
 
 export default function GalleryLightbox({ photos, selectedIndex, setSelectedIndex }: GalleryLightboxProps) {
     const photo = photos[selectedIndex];
-    console.log(photo)
     const photosLength = photos.length;
     return (
         <DialogContent className='w-screen h-screen bg-neutral-800 border-none flex flex-col justify-center '>
@@ -29,11 +24,11 @@ export default function GalleryLightbox({ photos, selectedIndex, setSelectedInde
                 <Image src={photo.file} alt={photo.title} width={700} height={700} className='w-fullred m-auto lg:h-full object-contain' />
                 <h1 className='text-2xl text-white font-po my-2 '>{photo.title}</h1>
             </div>
-            <button onClick={() => setSelectedIndex((prev: number) => prev == 0 ? 0 : prev - 1)}
+            <button onClick={() => setSelectedIndex((prev) => prev === null || prev === 0 ? 0 : prev - 1)}
                 className={cn('absolute left-8 text-2xl bottom-10 md:bottom-1/2',
                     selectedIndex == 0 ? 'text-black' : 'text-white p-2 border-2 border-orange-400 rounded-full bg-black hover:bg-orange-400 opacity-70 hover:opacity-100'
                 )}><GrPrevious /></button>
-            <button onClick={() => setSelectedIndex((prev: number) => prev < photos.length - 1 ? prev + 1 : prev)}
+            <button onClick={() => setSelectedIndex((prev) => prev === null ? 0 : prev < photos.length - 1 ? prev + 1 : prev)}
                 className={cn('absolute right-8 text-2xl bottom-10 md:bottom-1/2',
                     selectedIndex == photosLength - 1 ? 'text-black' : 'text-white p-2 border-2 border-orange-400 rounded-full bg-black hover:bg-orange-400 opacity-70 hover:opacity-100'
                 )}><GrNext /></button>

--- a/src/app/blog/gallery/_components/GalleryViewer.tsx
+++ b/src/app/blog/gallery/_components/GalleryViewer.tsx
@@ -6,17 +6,12 @@ import GalleryLightbox from './GalleryLightbox';
 import {
     Dialog,
 } from "@/components/ui/dialog"
-interface Photo {
-    id: string;
-    file: string;
-    title: string;
-    categories: { [key: string]: boolean };
-}
+import type { Photo, FilterCategory } from '@/types/Photo';
 
 
 interface GalleryViewerProps {
     photos: Photo[];
-    selectedCategory: string;
+    selectedCategory: FilterCategory;
 }
 
 
@@ -25,8 +20,8 @@ export default function GalleryViewer({ photos, selectedCategory }: GalleryViewe
     const searchParam = useSearchParams();
     const router = useRouter();
 
-    const filteredPhotos = photos.filter(photo => 
-        selectedCategory === 'all' ? true : photo.categories[selectedCategory]
+    const filteredPhotos = photos.filter(photo =>
+        selectedCategory === 'all' ? true : !!photo.categories[selectedCategory]
     );
 
     useEffect(() => {
@@ -46,8 +41,8 @@ export default function GalleryViewer({ photos, selectedCategory }: GalleryViewe
     return (
         <Dialog open={selectedIndex != null} onOpenChange={()=>setSelectedIndex(null)}>
             <div className='flex flex-col w-full relative gap-2 p-4 md:grid grid-cols-2 md:p-6 md:gap-6 items-center'>
-                {filteredPhotos.map((photo: any, i: number) => (
-                    <Image src={photo.file} alt={photo.title} key={i} width={700} height={700}
+                {filteredPhotos.map((photo: Photo, i: number) => (
+                    <Image src={photo.file} alt={photo.title} key={photo.id ?? i} width={700} height={700}
                         id={photo.id}
                         onClick={() => setSelectedIndex(i)}
                         className='w-full max-h-[800px] object-contain m-auto transition ease-in-out  hover:scale-105 duration-150 md: rounded-sm hover:rounded-none' />

--- a/src/app/blog/gallery/admin/_components/LoginForm.tsx
+++ b/src/app/blog/gallery/admin/_components/LoginForm.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useFormState, useFormStatus } from 'react-dom';
+import { loginAction } from '../actions';
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="w-full rounded-md bg-orange-400 text-black font-medium py-2 hover:bg-orange-300 disabled:opacity-50"
+    >
+      {pending ? 'Signing in...' : 'Sign in'}
+    </button>
+  );
+}
+
+export default function LoginForm() {
+  const [state, action] = useFormState(loginAction, undefined);
+
+  return (
+    <form action={action} className="flex flex-col gap-3 w-full max-w-sm mx-auto mt-16 p-6 bg-neutral-900/60 border border-neutral-700 rounded-lg">
+      <h1 className="text-xl text-white font-light text-center">Gallery Admin</h1>
+      <label className="text-sm text-neutral-300">Password</label>
+      <input
+        type="password"
+        name="password"
+        autoComplete="current-password"
+        required
+        className="px-3 py-2 rounded-md bg-neutral-800 text-white border border-neutral-700 focus:outline-none focus:border-orange-400"
+      />
+      {state?.error && (
+        <p className="text-sm text-red-400">{state.error}</p>
+      )}
+      <SubmitButton />
+    </form>
+  );
+}

--- a/src/app/blog/gallery/admin/_components/PhotoForm.tsx
+++ b/src/app/blog/gallery/admin/_components/PhotoForm.tsx
@@ -1,0 +1,261 @@
+'use client';
+
+import { useState, useTransition, type ChangeEvent, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { storage } from '@/utils/firebase';
+import {
+  PHOTO_CATEGORIES,
+  type Photo,
+  type PhotoCategory,
+  type PhotoCategoriesMap,
+} from '@/types/Photo';
+import { addPhoto, updatePhoto, deletePhoto } from '@/utils/firestore';
+
+interface PhotoFormProps {
+  existing: Photo[];
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || `photo-${Date.now()}`;
+}
+
+function emptyCategories(): PhotoCategoriesMap {
+  return {};
+}
+
+export default function PhotoForm({ existing }: PhotoFormProps) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+  const [status, setStatus] = useState<{ type: 'idle' | 'success' | 'error'; message?: string }>({ type: 'idle' });
+
+  const [editingId, setEditingId] = useState<string>('');
+  const [title, setTitle] = useState('');
+  const [categories, setCategories] = useState<PhotoCategoriesMap>(emptyCategories());
+  const [file, setFile] = useState<File | null>(null);
+  const [currentUrl, setCurrentUrl] = useState<string>('');
+  const [progress, setProgress] = useState<string>('');
+
+  const resetForm = () => {
+    setEditingId('');
+    setTitle('');
+    setCategories(emptyCategories());
+    setFile(null);
+    setCurrentUrl('');
+    setProgress('');
+  };
+
+  const handleSelectExisting = (e: ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value;
+    if (!id) {
+      resetForm();
+      return;
+    }
+    const p = existing.find((x) => x.id === id);
+    if (!p) return;
+    setEditingId(p.id);
+    setTitle(p.title ?? '');
+    setCategories(p.categories ?? {});
+    setFile(null);
+    setCurrentUrl(p.file ?? '');
+    setStatus({ type: 'idle' });
+  };
+
+  const toggleCategory = (cat: PhotoCategory) => {
+    setCategories((prev) => ({ ...prev, [cat]: !prev[cat] }));
+  };
+
+  const uploadFile = async (f: File, id: string): Promise<string> => {
+    const ext = f.name.split('.').pop() || 'jpg';
+    const path = `photos/${id}-${Date.now()}.${ext}`;
+    setProgress('Uploading image...');
+    const storageRef = ref(storage, path);
+    await uploadBytes(storageRef, f);
+    setProgress('Getting download URL...');
+    return getDownloadURL(storageRef);
+  };
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setStatus({ type: 'idle' });
+
+    if (!title.trim()) {
+      setStatus({ type: 'error', message: 'Title is required.' });
+      return;
+    }
+
+    if (!editingId && !file) {
+      setStatus({ type: 'error', message: 'Select an image file.' });
+      return;
+    }
+
+    try {
+      if (editingId) {
+        let fileUrl = currentUrl;
+        if (file) {
+          fileUrl = await uploadFile(file, editingId);
+        }
+        setProgress('Saving...');
+        const result = await updatePhoto(editingId, {
+          title: title.trim(),
+          categories,
+          file: fileUrl,
+        });
+        if (!result.ok) throw new Error('Update failed');
+        setStatus({ type: 'success', message: `Updated "${title}".` });
+      } else {
+        const id = slugify(title);
+        const fileUrl = await uploadFile(file as File, id);
+        setProgress('Saving...');
+        const result = await addPhoto({
+          id,
+          title: title.trim(),
+          categories,
+          file: fileUrl,
+        });
+        if (!result.ok) throw new Error('Create failed');
+        setStatus({ type: 'success', message: `Added "${title}".` });
+        resetForm();
+      }
+      setProgress('');
+      startTransition(() => router.refresh());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error.';
+      setStatus({ type: 'error', message });
+      setProgress('');
+    }
+  };
+
+  const onDelete = async () => {
+    if (!editingId) return;
+    if (!confirm(`Delete "${title}"? This removes the Firestore entry (not the Storage file).`)) return;
+    try {
+      const res = await deletePhoto(editingId);
+      if (!res.ok) throw new Error('Delete failed');
+      setStatus({ type: 'success', message: 'Deleted.' });
+      resetForm();
+      startTransition(() => router.refresh());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error.';
+      setStatus({ type: 'error', message });
+    }
+  };
+
+  return (
+    <div className="w-full max-w-2xl mx-auto p-4 md:p-6">
+      <div className="flex flex-col gap-2 mb-6">
+        <label className="text-sm text-neutral-300">Edit existing photo</label>
+        <select
+          value={editingId}
+          onChange={handleSelectExisting}
+          className="px-3 py-2 rounded-md bg-neutral-800 text-white border border-neutral-700"
+        >
+          <option value="">— New photo —</option>
+          {existing.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.title} ({p.id})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-4 bg-neutral-900/60 border border-neutral-700 rounded-lg p-6">
+        <h2 className="text-white text-lg font-light">
+          {editingId ? `Editing: ${editingId}` : 'New photo'}
+        </h2>
+
+        <label className="text-sm text-neutral-300">Title</label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          className="px-3 py-2 rounded-md bg-neutral-800 text-white border border-neutral-700 focus:outline-none focus:border-orange-400"
+        />
+
+        <label className="text-sm text-neutral-300">Categories</label>
+        <div className="flex flex-wrap gap-2">
+          {PHOTO_CATEGORIES.map((cat) => (
+            <label
+              key={cat}
+              className={`px-3 py-1 rounded-full text-sm cursor-pointer border ${
+                categories[cat]
+                  ? 'bg-orange-400 text-black border-orange-400'
+                  : 'bg-neutral-800 text-neutral-300 border-neutral-700'
+              }`}
+            >
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={!!categories[cat]}
+                onChange={() => toggleCategory(cat)}
+              />
+              {cat}
+            </label>
+          ))}
+        </div>
+
+        <label className="text-sm text-neutral-300">
+          {editingId ? 'Replace image (optional)' : 'Image file'}
+        </label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+          className="text-neutral-300 text-sm"
+        />
+
+        {(currentUrl || file) && (
+          <div className="mt-2">
+            <p className="text-xs text-neutral-400 mb-1">Preview</p>
+            <Image
+              src={file ? URL.createObjectURL(file) : currentUrl}
+              alt="preview"
+              width={400}
+              height={300}
+              unoptimized
+              className="max-h-64 w-auto object-contain border border-neutral-700 rounded"
+            />
+          </div>
+        )}
+
+        {progress && <p className="text-sm text-neutral-400">{progress}</p>}
+        {status.type === 'success' && <p className="text-sm text-green-400">{status.message}</p>}
+        {status.type === 'error' && <p className="text-sm text-red-400">{status.message}</p>}
+
+        <div className="flex gap-2 mt-2">
+          <button
+            type="submit"
+            disabled={pending || !!progress}
+            className="flex-1 rounded-md bg-orange-400 text-black font-medium py-2 hover:bg-orange-300 disabled:opacity-50"
+          >
+            {editingId ? 'Save changes' : 'Upload photo'}
+          </button>
+          {editingId && (
+            <>
+              <button
+                type="button"
+                onClick={resetForm}
+                className="rounded-md border border-neutral-600 text-neutral-200 px-4 py-2 hover:bg-neutral-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={onDelete}
+                className="rounded-md border border-red-600 text-red-400 px-4 py-2 hover:bg-red-900/30"
+              >
+                Delete
+              </button>
+            </>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/app/blog/gallery/admin/actions.ts
+++ b/src/app/blog/gallery/admin/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { redirect } from 'next/navigation';
+import { setAdminCookie, clearAdminCookie } from './session';
+
+export async function loginAction(_prev: { error?: string } | undefined, formData: FormData) {
+  const password = String(formData.get('password') ?? '');
+  if (!process.env.ADMIN_LOGIN) {
+    return { error: 'Server is not configured (ADMIN_LOGIN missing).' };
+  }
+  const ok = await setAdminCookie(password);
+  if (!ok) {
+    return { error: 'Invalid password.' };
+  }
+  redirect('/blog/gallery/admin');
+}
+
+export async function logoutAction() {
+  await clearAdminCookie();
+  redirect('/blog/gallery/admin');
+}

--- a/src/app/blog/gallery/admin/page.tsx
+++ b/src/app/blog/gallery/admin/page.tsx
@@ -1,0 +1,43 @@
+import { isAdmin } from './session';
+import { logoutAction } from './actions';
+import { getFirestoreImages } from '@/utils/firestore';
+import LoginForm from './_components/LoginForm';
+import PhotoForm from './_components/PhotoForm';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata = {
+  title: 'Gallery Admin | Dujin Kim',
+  robots: { index: false, follow: false },
+};
+
+export default async function AdminPage() {
+  const authed = await isAdmin();
+
+  if (!authed) {
+    return (
+      <div className="min-h-[60vh] flex items-center">
+        <LoginForm />
+      </div>
+    );
+  }
+
+  const { photos } = await getFirestoreImages();
+
+  return (
+    <div className="py-4">
+      <div className="flex items-center justify-between max-w-2xl mx-auto px-4 md:px-6">
+        <h1 className="text-2xl md:text-3xl font-light text-neutral-200">Gallery Admin</h1>
+        <form action={logoutAction}>
+          <button
+            type="submit"
+            className="text-sm text-neutral-400 hover:text-white border border-neutral-700 rounded-md px-3 py-1"
+          >
+            Sign out
+          </button>
+        </form>
+      </div>
+      <PhotoForm existing={photos} />
+    </div>
+  );
+}

--- a/src/app/blog/gallery/admin/session.ts
+++ b/src/app/blog/gallery/admin/session.ts
@@ -1,0 +1,51 @@
+import 'server-only';
+import { cookies } from 'next/headers';
+import { createHash, timingSafeEqual } from 'crypto';
+
+export const ADMIN_COOKIE = 'gallery_admin_session';
+const COOKIE_MAX_AGE = 60 * 60 * 8;
+
+function expectedToken(): string | null {
+  const secret = process.env.ADMIN_LOGIN;
+  if (!secret) return null;
+  return createHash('sha256').update(secret).digest('hex');
+}
+
+export async function isAdmin(): Promise<boolean> {
+  const token = expectedToken();
+  if (!token) return false;
+  const cookieVal = cookies().get(ADMIN_COOKIE)?.value;
+  if (!cookieVal) return false;
+  const a = Buffer.from(cookieVal);
+  const b = Buffer.from(token);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function requireAdmin(): Promise<void> {
+  if (!(await isAdmin())) {
+    throw new Error('Unauthorized');
+  }
+}
+
+export async function setAdminCookie(password: string): Promise<boolean> {
+  const secret = process.env.ADMIN_LOGIN;
+  if (!secret) return false;
+  const expected = Buffer.from(secret);
+  const given = Buffer.from(password);
+  if (expected.length !== given.length) return false;
+  if (!timingSafeEqual(expected, given)) return false;
+  const token = createHash('sha256').update(secret).digest('hex');
+  cookies().set(ADMIN_COOKIE, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+    maxAge: COOKIE_MAX_AGE,
+  });
+  return true;
+}
+
+export async function clearAdminCookie(): Promise<void> {
+  cookies().delete(ADMIN_COOKIE);
+}

--- a/src/types/Photo.ts
+++ b/src/types/Photo.ts
@@ -1,0 +1,26 @@
+export const PHOTO_CATEGORIES = [
+  'architecture',
+  'design',
+  'landscape',
+  'lifestyle',
+  'travel',
+] as const;
+
+export type PhotoCategory = (typeof PHOTO_CATEGORIES)[number];
+
+export type PhotoCategoriesMap = Partial<Record<PhotoCategory, boolean>>;
+
+export interface Photo {
+  id: string;
+  file: string;
+  title: string;
+  categories: PhotoCategoriesMap;
+  cameraInfo?: Record<string, unknown>;
+}
+
+export type PhotoInput = Omit<Photo, 'id' | 'cameraInfo'> & {
+  id?: string;
+};
+
+export const FILTER_CATEGORIES = ['all', ...PHOTO_CATEGORIES] as const;
+export type FilterCategory = (typeof FILTER_CATEGORIES)[number];

--- a/src/utils/firebase.js
+++ b/src/utils/firebase.js
@@ -1,5 +1,6 @@
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps, getApp } from "firebase/app";
 import { getFirestore } from "firebase/firestore";
+import { getStorage } from "firebase/storage";
 
 
 const firebaseConfig = {
@@ -10,9 +11,10 @@ const firebaseConfig = {
   messagingSenderId: "14854024796",
   appId: process.env.FIREBASE_APP_ID,
   measurementId: "G-S0Q5NLEX5B"
-};;
+};
 
-const app = initializeApp(firebaseConfig);
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const db = getFirestore(app);
+const storage = getStorage(app);
 
-export {db}
+export { app, db, storage }

--- a/src/utils/firestore.tsx
+++ b/src/utils/firestore.tsx
@@ -1,21 +1,78 @@
 'use server'
 import 'server-only'
-import {cache} from 'react'
+import { cache } from 'react'
 import { db } from "@/utils/firebase";
-import { collection, getDocs , updateDoc} from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDocs,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+} from "firebase/firestore";
+import { revalidatePath } from 'next/cache';
+import { requireAdmin } from '@/app/blog/gallery/admin/session';
+import type { Photo, PhotoCategoriesMap } from '@/types/Photo';
 
 
-
-export const getFirestoreImages = cache( async () => {
-    "use server"
-    const querySnapshot = await getDocs(collection(db, "photos"));
-    const photos = querySnapshot.docs.map((doc) => {
-      const data = doc.data();
-      delete data.cameraInfo;
-      return data;
-    });
-  
+export const getFirestoreImages = cache(async () => {
+  "use server"
+  const querySnapshot = await getDocs(collection(db, "photos"));
+  const photos: Photo[] = querySnapshot.docs.map((snap) => {
+    const data = snap.data() as Partial<Photo>;
+    const { cameraInfo: _omitted, ...rest } = data;
     return {
-      photos
+      id: snap.id,
+      file: rest.file ?? '',
+      title: rest.title ?? '',
+      categories: (rest.categories ?? {}) as PhotoCategoriesMap,
     };
   });
+
+  return {
+    photos
+  };
+});
+
+
+export async function addPhoto(photo: {
+  id: string;
+  file: string;
+  title: string;
+  categories: PhotoCategoriesMap;
+}) {
+  "use server"
+  await requireAdmin();
+  const ref = doc(db, "photos", photo.id);
+  await setDoc(ref, {
+    file: photo.file,
+    title: photo.title,
+    categories: photo.categories,
+  });
+  revalidatePath('/blog/gallery');
+  return { ok: true as const, id: photo.id };
+}
+
+
+export async function updatePhoto(
+  id: string,
+  patch: Partial<Pick<Photo, 'file' | 'title' | 'categories'>>,
+) {
+  "use server"
+  await requireAdmin();
+  const ref = doc(db, "photos", id);
+  await updateDoc(ref, patch);
+  revalidatePath('/blog/gallery');
+  revalidatePath(`/blog/gallery/${id}`);
+  return { ok: true as const, id };
+}
+
+
+export async function deletePhoto(id: string) {
+  "use server"
+  await requireAdmin();
+  const ref = doc(db, "photos", id);
+  await deleteDoc(ref);
+  revalidatePath('/blog/gallery');
+  return { ok: true as const, id };
+}


### PR DESCRIPTION
## Summary
- Adds a password-gated admin page at `/blog/gallery/admin` for uploading, editing, and deleting gallery photos. Auth compares the submitted password to `ADMIN_LOGIN` (from `.env.local`) via `timingSafeEqual` and stores a SHA-256 token in an httpOnly cookie.
- Upload form (client component) writes images to Firebase Storage, then calls new auth-guarded server actions (`addPhoto`, `updatePhoto`, `deletePhoto`) in [src/utils/firestore.tsx](src/utils/firestore.tsx) that `revalidatePath('/blog/gallery')`.
- Extracts a universal `Photo` type (plus `PhotoCategory`, `PhotoCategoriesMap`, `FilterCategory`, `PHOTO_CATEGORIES`, `FILTER_CATEGORIES`) to [src/types/Photo.ts](src/types/Photo.ts) and applies it to `GalleryViewer`, `GalleryContainer`, `GalleryLightbox`, and `FilterTags`, replacing local `any`/ad-hoc shapes.

## What changed
- New: `src/app/blog/gallery/admin/{page.tsx,session.ts,actions.ts,_components/LoginForm.tsx,_components/PhotoForm.tsx}`
- New: `src/types/Photo.ts` — single source of truth for photo categories + Photo shape
- Changed: `src/utils/firestore.tsx` — typed `Photo[]` return, new `addPhoto` / `updatePhoto` / `deletePhoto` server actions guarded by `requireAdmin()`
- Changed: `src/utils/firebase.js` — exports `storage`, guards against double-init with `getApps().length`
- Changed: gallery components now use shared types; `FilterTags` now derives its list from `FILTER_CATEGORIES`

## Setup
Add to `.env.local`:
```
ADMIN_LOGIN=your-password
```
Then visit `/blog/gallery/admin`. The admin route is `noindex` and `force-dynamic`.

## Notes for reviewer
- Cookie is httpOnly, SameSite=Lax, `secure` in production, 8h TTL; token is `sha256(ADMIN_LOGIN)` so rotating the env var invalidates existing sessions.
- Image uploads go to Firebase Storage (`photos/<id>-<timestamp>.<ext>`) from the client; only Firestore writes are done through server actions. Make sure your Storage rules allow this, or swap to a server-side upload path if you prefer.
- Delete removes the Firestore document only — the Storage blob is not purged (called out in the confirm dialog).
- `next.config.js` already allows `firebasestorage.googleapis.com` for `next/image`.
- `tsc --noEmit` is clean. `next lint` shows only pre-existing warnings (no new ones introduced).

## Test plan
- [ ] Set `ADMIN_LOGIN` in `.env.local` and run `next dev`
- [ ] Visit `/blog/gallery/admin` → login form renders; wrong password shows error
- [ ] Log in with correct password → upload form renders; signed-in session persists across reloads
- [ ] Upload a new photo with title + categories → appears in `/blog/gallery` after refresh; correct category filters match
- [ ] Select existing photo from dropdown → form populates; edit title/categories → saved; optional replace-image works
- [ ] Delete a photo → removed from `/blog/gallery`
- [ ] Sign out → returns to login form

🤖 Generated with [Claude Code](https://claude.com/claude-code)